### PR TITLE
Fix toolkits not working for large files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DEP_CC  ?= gcc
 AR      ?= ar
 RANLIB  ?= ranlib
 STRIP   ?= strip
-CFLAGS  += -O2 -Wall
+CFLAGS  += -O2 -Wall -D_FILE_OFFSET_BITS=64
 LDFLAGS += -lm -lz
 
 # libsparse


### PR DESCRIPTION
Adding -D_FILE_OFFSET_BITS=64 to CFLAGS can fix the problem.