### PR TITLE
Samsung compatibility

### DIFF
--- a/simg_dump.py
+++ b/simg_dump.py
@@ -48,7 +48,7 @@ def main():
     opts, args = getopt.getopt(sys.argv[1:],
                                "vsc:",
                                ["verbose", "showhash", "csvfile"])
-  except getopt.GetoptError, e:
+  except getopt.GetoptError as e:
     print(e)
     usage(me)
   for o, a in opts:
@@ -226,6 +226,12 @@ def main():
     csvfile.close()
 
   sys.exit(0)
+
+# Python 3 shim
+try:
+    xrange
+except NameError:
+    xrange = range
 
 if __name__ == "__main__":
   main()

--- a/simg_dump.py
+++ b/simg_dump.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from __future__ import print_function
+import binascii
 import csv
 import getopt
 import hashlib
@@ -94,12 +95,12 @@ def main():
       print("%s: %s: I only know about version 1.0, but this is version %u.%u"
             % (me, path, major_version, minor_version))
       continue
-    if file_hdr_sz != 28:
-      print("%s: %s: The file header size was expected to be 28, but is %u."
+    if file_hdr_sz < 28:
+      print("%s: %s: The file header size was expected to be at least 28, but is %u."
             % (me, path, file_hdr_sz))
       continue
-    if chunk_hdr_sz != 12:
-      print("%s: %s: The chunk header size was expected to be 12, but is %u."
+    if chunk_hdr_sz < 12:
+      print("%s: %s: The chunk header size was expected to be at least 12, but is %u."
             % (me, path, chunk_hdr_sz))
       continue
 
@@ -108,6 +109,11 @@ def main():
 
     if image_checksum != 0:
       print("checksum=0x%08X" % (image_checksum))
+
+    if file_hdr_sz > 28:
+      header_extra = FH.read(file_hdr_sz - 28)
+      print("%s: Header extra bytes: %s"
+            % (me, binascii.hexlify(header_extra)))
 
     if not output:
       continue
@@ -127,7 +133,7 @@ def main():
       chunk_type = header[0]
       chunk_sz = header[2]
       total_sz = header[3]
-      data_sz = total_sz - 12
+      data_sz = total_sz - chunk_hdr_sz
       curhash = ""
       curtype = ""
       curpos = FH.tell()
@@ -135,6 +141,10 @@ def main():
       if verbose > 0:
         print("%4u %10u %10u %7u %7u" % (i, curpos, data_sz, offset, chunk_sz),
               end=" ")
+        if chunk_hdr_sz > 12:
+          header_extra = FH.read(chunk_hdr_sz - 12)
+          print("[Extra bytes: %s]"
+                % (binascii.hexlify(header_extra)), end=" ")
 
       if chunk_type == 0xCAC1:
         if data_sz != (chunk_sz * blk_sz):

--- a/simg_samsungify.d
+++ b/simg_samsungify.d
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2018 Vladimir Panteleev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Description:
+ *
+ * Tweak a sparse-image file to conform to Samsung's proprietary
+ * format modifications.
+ *
+ * This allows creating sparse-image files directly flashable e.g. on
+ * SM-N910H with Odin/Heimdall.
+ */
+
+module simg_samsungify;
+
+import std.exception;
+import std.mmfile;
+import std.stdio;
+
+struct SparseHeader
+{
+	uint magic = 0xed26ff3a;
+    ushort major_version = 1;
+    ushort minor_version = 0;
+    ushort file_hdr_sz;
+    ushort chunk_hdr_sz;
+    uint blk_sz;
+    uint total_blks;
+    uint total_chunks;
+    uint image_checksum;
+}
+
+struct ChunkHeader
+{
+    ubyte[2] chunk_type;
+    ushort reserved1;
+    uint chunk_sz;
+    uint total_sz;
+}
+
+immutable uint[1] headerExtra = [0];
+immutable uint[1] chunkExtra = [0x00007fcb];
+
+void main(string[] args)
+{
+	enforce(args.length == 3, "Usage: simg_samsungify IN-FILE-NAME OUT-FILE-NAME");
+	string inFileName = args[1];
+	string outFileName = args[2];
+
+	auto m = new MmFile(inFileName);
+	enforce(m.length >= SparseHeader.sizeof, "Not enough bytes for header");
+	auto p = cast(ubyte*)m[].ptr;
+	auto pHeader = cast(SparseHeader*)p;
+	enforce(pHeader.file_hdr_sz == SparseHeader.sizeof,
+		"Wrong file header size (already samsung-ified?)");
+	enforce(pHeader.chunk_hdr_sz == ChunkHeader.sizeof,
+		"Wrong chunk header size (already samsung-ified?)");
+
+	auto newHeader = *pHeader;
+	newHeader.file_hdr_sz += headerExtra.sizeof;
+	newHeader.chunk_hdr_sz += chunkExtra.sizeof;
+
+	auto o = File(outFileName, "wb");
+	o.rawWrite((&newHeader)[0..1]);
+	o.rawWrite(headerExtra[]);
+
+	auto end = p + m.length;
+	p += pHeader.file_hdr_sz;
+	while (p < end)
+	{
+		enforce(p + pHeader.chunk_hdr_sz <= end,
+			"Not enough bytes for chunk header");
+		auto pChunkHeader = cast(ChunkHeader*)p;
+		//writeln(*pChunkHeader);
+		enforce(p + pChunkHeader.total_sz <= end,
+			"Not enough bytes for chunk");
+		auto dataLength = pChunkHeader.total_sz - pHeader.chunk_hdr_sz;
+		auto newChunkHeader = *pChunkHeader;
+		newChunkHeader.total_sz += chunkExtra.sizeof;
+		o.rawWrite((&newChunkHeader)[0..1]);
+		o.rawWrite(chunkExtra);
+		p += pHeader.chunk_hdr_sz;
+		o.rawWrite(p[0..dataLength]);
+		p += dataLength;
+	}
+}


### PR DESCRIPTION
Samsung seems to use a slightly different simg format, where both the file and chunk headers are 4 bytes larger.

I wasn't sure about adding this to the C `sparse` files, as those seem to be borrowed from elsewhere; instead, I included an utility to convert a "standard" sparse-image to one Samsung's bootloaders can understand.

Also included are some fixes for `simg_dump.py`.