### PR TITLE
output_file: Fix for non-4k pagesize.

### DIFF
--- a/output_file.c
+++ b/output_file.c
@@ -699,7 +699,7 @@ int write_fd_chunk(struct output_file *out, unsigned int len, int fd, int64_t of
     uint64_t buffer_size;
     char *ptr;
 
-    aligned_offset = offset & ~(4096 - 1);
+    aligned_offset = offset & ~(sysconf(_SC_PAGESIZE) - 1);
     aligned_diff = offset - aligned_offset;
     buffer_size = (uint64_t)len + (uint64_t)aligned_diff;
 


### PR DESCRIPTION
aarch64 supports 64k pages, but the hardcoded 4k value causes corruption on 64k pages.