### PR TITLE
Fix for Apple Silicon

### DIFF
--- a/output_file.cpp
+++ b/output_file.cpp
@@ -657,7 +657,7 @@ int write_fd_chunk(struct output_file* out, unsigned int len, int fd, int64_t of
   uint64_t buffer_size;
   char* ptr;
 
-  aligned_offset = offset & ~(4096 - 1);
+  aligned_offset = offset & ~(sysconf(_SC_PAGESIZE) - 1);
   aligned_diff = offset - aligned_offset;
   buffer_size = (uint64_t)len + (uint64_t)aligned_diff;
 


### PR DESCRIPTION
This is the same change as was previously accepted in pull request #15, and subsequently lost when "output_file.c" was replaced with "output_file.cpp."

simg2img does not work on Apple Silicon-based Macs, failing with an error "Cannot write output file."  This is because simg2img makes a call to mmap64 with an offset of 4096 (the page size on x86-based systems). mmap64 requires that the offset be a multiple of the page size, and the page size on Apple Silicon is 16384; therefore, the mmap64 call fails.

This change calculates the appropriate offset using the actual page size of the system rather than a hardcoded 4096.