### PR TITLE
Fix calloc argument order for GCC 14

### DIFF
--- a/backed_block.cpp
+++ b/backed_block.cpp
@@ -111,7 +111,7 @@ void backed_block_destroy(struct backed_block* bb) {
 
 struct backed_block_list* backed_block_list_new(unsigned int block_size) {
   struct backed_block_list* b =
-      reinterpret_cast<backed_block_list*>(calloc(sizeof(struct backed_block_list), 1));
+      reinterpret_cast<backed_block_list*>(calloc(1, sizeof(struct backed_block_list)));
   b->block_size = block_size;
   return b;
 }

--- a/simg2simg.cpp
+++ b/simg2simg.cpp
@@ -72,7 +72,7 @@ int main(int argc, char* argv[]) {
     exit(-1);
   }
 
-  out_s = (struct sparse_file**)calloc(sizeof(struct sparse_file*), files);
+  out_s = (struct sparse_file**)calloc(files, sizeof(struct sparse_file*));
   if (!out_s) {
     fprintf(stderr, "Failed to allocate sparse file array\n");
     exit(-1);

--- a/sparse.cpp
+++ b/sparse.cpp
@@ -28,7 +28,7 @@
 #include "sparse_format.h"
 
 struct sparse_file* sparse_file_new(unsigned int block_size, int64_t len) {
-  struct sparse_file* s = reinterpret_cast<sparse_file*>(calloc(sizeof(struct sparse_file), 1));
+  struct sparse_file* s = reinterpret_cast<sparse_file*>(calloc(1, sizeof(struct sparse_file)));
   if (!s) {
     return nullptr;
   }


### PR DESCRIPTION
GCC 14 makes this an error by default.